### PR TITLE
add `spec.ports.nodePort` mosquitto service.yaml

### DIFF
--- a/mosquitto/Chart.yaml
+++ b/mosquitto/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.6"
 description: Eclipse Mosquitto is an open source message broker which implements MQTT version 5, 3.1.1 and 3.1
 name: mosquitto
-version: 0.1.1
+version: 0.1.2

--- a/mosquitto/templates/service.yaml
+++ b/mosquitto/templates/service.yaml
@@ -19,6 +19,9 @@ spec:
   {{- range $key, $value := . }}
     - name: {{ $key }}
       port: {{ $value.port }}
+    {{- if $value.nodePort }}
+      nodePort: {{ $value.nodePort }}
+    {{- end }}
       targetPort: {{ $key }}
       protocol: {{ default "TCP" $value.protocol }}
   {{- end }}


### PR DESCRIPTION
In order to provide external access to mqtt port 1883 (non websocket)
I've modified mosquitto/templates/service.yaml to publish `nodePort`
if present.

This allows the `Values.service.type` to be `NodePort` with a consistent port.