### PR TITLE
[mosquitto] add support acl_file

### DIFF
--- a/mosquitto/Chart.yaml
+++ b/mosquitto/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.6.12"
 description: Eclipse Mosquitto is an open source message broker which implements MQTT version 5, 3.1.1 and 3.1
 name: mosquitto
-version: 2.1.0
+version: 2.1.1

--- a/mosquitto/Chart.yaml
+++ b/mosquitto/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.6.12"
 description: Eclipse Mosquitto is an open source message broker which implements MQTT version 5, 3.1.1 and 3.1
 name: mosquitto
-version: 2.1.1
+version: 2.2.0

--- a/mosquitto/templates/configmap.yaml
+++ b/mosquitto/templates/configmap.yaml
@@ -9,4 +9,7 @@ data:
   {{- if and .Values.authentication.passwordEntries .Values.authentication.passwordFilePath }}
     password_file {{ .Values.authentication.passwordFilePath }}
   {{- end }}
+  {{- if and .Values.authorization.acls .Values.authorization.aclfilePath }}
+    acl_file {{ .Values.authorization.aclfilePath }}
+  {{- end }}
 {{- end }}

--- a/mosquitto/templates/deployment.yaml
+++ b/mosquitto/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
           secret:
             secretName: {{ include "mosquitto.fullname" . }}
       {{- end }}
-      {{- if and .Values.authorizations.acls .Values.authorizations.aclfilePath }}
+      {{- if and .Values.authorization.acls .Values.authorization.aclfilePath }}
         - name: aclfile
           secret:
             secretName: {{ include "mosquitto.fullname" . }}

--- a/mosquitto/templates/deployment.yaml
+++ b/mosquitto/templates/deployment.yaml
@@ -69,6 +69,11 @@ spec:
               mountPath: {{ .Values.authentication.passwordFilePath }}
               subPath: passwordfile
           {{- end }}
+          {{- if and .Values.authorization.acls .Values.authorization.aclfilePath }}
+            - name: aclfile
+              mountPath: {{ .Values.authorization.aclfilePath }}
+              subPath: aclfile
+          {{- end }}
           {{- with .Values.extraVolumeMounts }}
             {{ toYaml . | indent 12 | trim }}
           {{- end }}
@@ -85,6 +90,11 @@ spec:
         {{- end }}
       {{- if and .Values.authentication.passwordEntries .Values.authentication.passwordFilePath }}
         - name: passwordfile
+          secret:
+            secretName: {{ include "mosquitto.fullname" . }}
+      {{- end }}
+      {{- if and .Values.authorizations.acls .Values.authorizations.aclfilePath }}
+        - name: aclfile
           secret:
             secretName: {{ include "mosquitto.fullname" . }}
       {{- end }}

--- a/mosquitto/templates/secret.yaml
+++ b/mosquitto/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authentication.passwordEntries }}
+{{- if or .Values.authentication.passwordEntries  .Values.authorization.acls }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,10 @@ metadata:
   labels: {{- include "mosquitto.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Values.authentication.passwordEntries }}
   passwordfile: {{ .Values.authentication.passwordEntries | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.authorization.acls }}
+  aclfile: {{ .Values.authorization.acls | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/mosquitto/templates/secret.yaml
+++ b/mosquitto/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.authentication.passwordEntries  .Values.authorization.acls }}
+{{- if or .Values.authentication.passwordEntries .Values.authorization.acls }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/mosquitto/values.yaml
+++ b/mosquitto/values.yaml
@@ -82,6 +82,22 @@ authentication:
   #   user2:$6$b5vYuHrSLj48Ii32$NjlbnatIaUQSsNvxxTpawpav6NPyZ8QhGrdEVGtyU1rgEGjNzVGKlstRg29FV6MFTPs/ugPA8D5I5+qRcIMXSg==
   passwordFilePath: "/etc/mosquitto/passwordfile"
 
+authorization:
+  acls: ""
+  # To use authorizations with mosquitto, you can set a list of per user or pattern-based rules.
+  # reference https://mosquitto.org/man/mosquitto-conf-5.html for further information.
+  # For example:
+  # acls: |-
+      # zigbee2mqtt ACLs
+      # user zigbee2mqtt
+      # topic readwrite zigbee2mqtt/#
+      # topic readwrite homeassistant/#
+      # Tasmota-compatible ACLs
+      # pattern read cmnd/%u/#
+      # pattern write stat/%u/#
+      # pattern write tele/%u/#
+  aclfilePath: "/etc/mosquitto/aclfile"
+
 existingConfigMap: ""
 config: |
   persistence true


### PR DESCRIPTION
PR add support for mosquitto authorisations 'acl_file' as outlined [here.](https://mosquitto.org/man/mosquitto-conf-5.html)

Have annotated `values.yaml` with examples and bumped version number.