### PR TITLE
Bump snipe-it version, change health check to new health check path

### DIFF
--- a/snipeit/Chart.yaml
+++ b/snipeit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snipeit
-version: 3.1.0
-appVersion: 5.0.12
+version: 3.2.0
+appVersion: 5.1.0
 description: A free open source IT asset/license management system
 keywords:
 - snipeit

--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -53,13 +53,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /login
+              path: /health
               port: 80
             periodSeconds: 15
             timeoutSeconds: 3
           readinessProbe:
             httpGet:
-              path: /login
+              path: /health
               port: 80
             periodSeconds: 15
             timeoutSeconds: 3

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -9,7 +9,7 @@ deploymentStrategy:
 
 image:
   repository: snipe/snipe-it
-  tag: v5.0.12
+  tag: v5.1.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Hello,

Please find a PR which update snipe it to version 5.1.0 (Security update) and use the new `/health` endpoint for readness and liveness probe.