### PR TITLE
snipeit: Bugfix in initcontainer

### DIFF
--- a/snipeit/Chart.yaml
+++ b/snipeit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: snipeit
-version: 3.2.1
+version: 3.2.2
 appVersion: 5.1.3
 description: A free open source IT asset/license management system
 keywords:

--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       initContainers:
         - name: config-data
           image: busybox
-          command: ["/bin/chown", "-R", "1000", "/var/www/html/storage/framework/sessions"]
+          command: ["sh", "-c", "find {{ .Values.persistence.sessions.mountPath }} -not -user 1000 -exec chown 1000 {} \\+"]
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.sessions.mountPath }}

--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -24,11 +24,11 @@ spec:
       initContainers:
         - name: config-data
           image: busybox
-          command: ["sh", "-c", "find", "/var/www/html/storage/framework/sessions", "-not", "-user", "1000", "-exec", "chown 1000 {} \\+"]
+          command: ["/bin/chown", "-R", "1000", "/var/www/html/storage/framework/sessions"]
           volumeMounts:
             - name: data
-              mountPath: /var/www/html/storage/framework/sessions
-              subPath: sessions
+              mountPath: {{ .Values.persistence.sessions.mountPath }}
+              subPath: {{ .Values.persistence.sessions.subPath }}
       containers:
         - name: {{ include "snipeit.fullname" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Hi,
**sh -c find /var/www/html/.....** does not what it was intended here. Actually, the command executed here is simply **sh -c find**, the rest is ignored. find and all it's parameters should be in quotes, so that the **-c** has only **one** argument.
I replaced this simply by **chown -R ...**, which has the same effect. I don't think wrapping everything in **sh -c "command arg arg arg"** is necessary.
It solves issues #150 and #127.

Also, the init container definition used the hardcoded path _/var/www/html/storage/framework/sessions_. I replaced it with _.Values.persistence.sessions.mountPath_, like it is done in the main container.
