### PR TITLE
Update external-service to comply with 1.22+ cluster

### DIFF
--- a/external-service/templates/ingress.yaml
+++ b/external-service/templates/ingress.yaml
@@ -1,6 +1,8 @@
-{{- if .Values.ingress.enabled -}}
+{{- if $.Values.ingress.enabled -}}
 {{- $fullName := include "external-service.fullname" . -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -10,14 +12,14 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "external-service.labels" . | nindent 4 }}
-{{- with .Values.ingress.annotations }}
+{{- with $.Values.ingress.annotations }}
   annotations:
   {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}
 spec:
-{{- range .Values.ports }}
+{{- range $.Values.ports }}
 {{- if .ingress.tls }}
   tls:
   {{- range .ingress.tls }}
@@ -30,7 +32,7 @@ spec:
 {{- end }}
 {{- end }}
   rules:
-{{- range .Values.ports }}
+{{- range $.Values.ports }}
 {{- $svcPort := .port }}
   {{- range .ingress.hosts }}
     - host: {{ .host | quote }}
@@ -38,9 +40,18 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
+          {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+          {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/external-service/values.yaml
+++ b/external-service/values.yaml
@@ -3,6 +3,7 @@ fullnameOverride: ""
 
 ingress:
   enabled: false
+  annotations: {}
 
 type: ClusterIP
 


### PR DESCRIPTION
Update to [comply with 1.22+ cluster](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)