### PR TITLE
allow securityContext for snipe-it deployment

### DIFF
--- a/snipeit/Chart.yaml
+++ b/snipeit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: snipeit
-version: 3.3.0
+version: 3.3.1
 appVersion: 5.3.0
 description: A free open source IT asset/license management system
 keywords:

--- a/snipeit/README.md
+++ b/snipeit/README.md
@@ -72,7 +72,7 @@ and their default values.
 | `ingress.enabled`                    | Whether or not to enable Ingress                      | `true`                         |
 | `ingress.className`                  | Ingress Class Name                                    | `""`                           |
 | `ingress.annotations`                | Custom Ingress Annotations                            | `{}`                           |
-| `ingress.path`                       | Root Path for the Ingress Ressource                   | `/`                            |
+| `ingress.path`                       | Root Path for the Ingress Resource                    | `/`                            |
 | `ingress.hosts`                      | URL where Snipe-IT will be accessed                   | `example.local`                |
 | `ingress.tls`                        | Configuration for SecretName and TLS-Hosts            | `[]`                           |
 | `mysql.enabled`                      | Whether or not to deploy a MySQL Deployment           | `true`                         |
@@ -90,7 +90,7 @@ and their default values.
 | `deploymentStrategy`                 | Deployment strategy	                                 | `{ "type": "RollingUpdate" }`  |
 | `revisionHistoryLimit`               | The number of old Replicas to keep to allow rollback. | `0`                            |
 | `service.type`                       | Type of service to create                             | `ClusterIP`                    |
-| `service.annotations`                 | Annotations of service to create                      | `{}`                           |
+| `service.annotations`                | Annotations of service to create                      | `{}`                           |
 | `service.clusterIP`                  | Internal cluster service IP                           | `nil`                          |
 | `service.loadBalancerIP`             | IP address to assign to load balancer (if supported)  | `nil`                          |
 | `service.loadBalancerSourceRanges`   | list of IP CIDRs allowed access to lb (if supported)  | `[]`                           |
@@ -99,6 +99,9 @@ and their default values.
 | `nodeSelector`                       | Node labels for pod assignment                        | `{}`                           |
 | `tolerations`                        | Toleration labels for pod assignment                  | `[]`                           |
 | `affinity`                           | Affinity settings for pod assignment                  | `{}`                           |
+| `podSecurityContext`                 | Deployment's pods securityContext                     | `{}`                           |
+| `securityContext`                    | Deployment's container securityContext                | `{}`                           |
+| `initContainer.securityContext`      | Deployment's initContainer securityContext            | `{}`                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         - name: config-data
           image: busybox
           command: ["sh", "-c", "find {{ .Values.persistence.sessions.mountPath }} -not -user 1000 -exec chown 1000 {} \\+"]
+          {{- if .Values.initContainer.securityContext }}
+          securityContext:
+          {{- toYaml .Values.initContainer.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.sessions.mountPath }}
@@ -67,6 +71,10 @@ spec:
           resources:
             {{ toYaml . | nindent 12 }}
         {{- end }}
+          {{- if .Values.securityContext }}
+          securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.www.mountPath }}
@@ -94,3 +102,7 @@ spec:
       tolerations:
         {{ toYaml . | indent 8 | trim }}
     {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 8}}
+      {{- end }}

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -114,3 +114,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+initContainer:
+  securityContext: {}


### PR DESCRIPTION
Signed-off-by: kostas <kostavro@gmail.com>

Adding support to configure `securityContext` for Snipe-IT, at pod, container and initContainer level.