### PR TITLE
Enable podAnnotations on mosquitto deployment

### DIFF
--- a/mosquitto/templates/deployment.yaml
+++ b/mosquitto/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- if and .Values.authentication.passwordEntries .Values.authentication.passwordFilePath }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
       {{- end }}
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/mosquitto/values.yaml
+++ b/mosquitto/values.yaml
@@ -10,6 +10,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+## Pod Annotations
+# podAnnotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
As title, enable setting custom podAnnotations on the mosquitto helm chart.

I use the same pattern as is on Matomo Chart here:
https://github.com/t3n/helm-charts/blob/master/matomo/templates/deployment.yaml#L25-L27
