### PR TITLE
Add pod annotation capabilities

### DIFF
--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         {{ include "snipeit.selector" . | indent 8 | trim }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- with .Values.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       initContainers:
         - name: config-data

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -110,6 +110,8 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+podAnnotations: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
It gave the ability to add annotation on pod deployment of snipeit. It is usefull for by example add this
```
podAnnotations:
        backup.velero.io/backup-volumes: data
```
fix #183