### PR TITLE
Update Snipe-IT Helm Chart to Support Manually Created DB Configuration Secret and External Manifests

### DIFF
--- a/snipeit/README.md
+++ b/snipeit/README.md
@@ -66,6 +66,7 @@ and their default values.
 | `config.snipeit.timezone`            | Snipe-IT Timezone                                     | `Europe/Berlin`                |
 | `config.snipeit.locale`              | Snipe-IT Locale                                       | `en`                           |
 | `config.snipeit.envConfig`           | Configure Environment Values                          | `{}`                           |
+| `config.externalSecrets `            | External Secrets to for db configuration              | `[]`                           |
 | `image.repository`                   | Image Repository                                      | `snipe/snipe-it`               |
 | `image.tag`                          | Image Tag                                             | `4.6.16`                       |
 | `image.pullPolicy`                   | Image Pull Policy                                     | `IfNotPresent`                 |
@@ -99,7 +100,7 @@ and their default values.
 | `nodeSelector`                       | Node labels for pod assignment                        | `{}`                           |
 | `tolerations`                        | Toleration labels for pod assignment                  | `[]`                           |
 | `affinity`                           | Affinity settings for pod assignment                  | `{}`                           |
-
+| `extraManifests`                     | Add additional manifests to deploy	                   | `[]`                           |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```
@@ -158,3 +159,31 @@ config:
       MAIL_FROM_NAME: Snipe-IT
 ```
 
+### External Secrets
+
+To use manually created secrets for the database configuration, use the `config.externalSecret`.
+You can create a secret with the following command:
+
+```bash
+kubectl create secret generic my-db-secret \
+  --from-literal=MYSQL_USER=<your_mysql_user> \
+  --from-literal=MYSQL_DATABASE=<your_mysql_database> \
+  --from-literal=MYSQL_PASSWORD=<your_mysql_password> \
+  --from-literal=MYSQL_PORT_3306_TCP_ADDR=<your_mysql_host> \
+  --from-literal=MYSQL_PORT_3306_TCP_PORT=<your_mysql_port> \
+  --from-literal=APP_KEY=<your_app_key>
+```
+
+## Additional manifests
+It is possible to add additional manifests into a deployment, to extend the chart. One of the reason is to deploy a manifest specific to a cloud provider ( BackendConfig on GKE for example ).
+
+```yaml
+extraManifests:
+  - apiVersion: cloud.google.com/v1beta1
+    kind: BackendConfig
+    metadata:
+      name: "{{ .Release.Name }}-test"
+    spec:
+      securityPolicy:
+        name: "gcp-cloud-armor-policy-test"
+```        

--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -49,9 +49,15 @@ spec:
               value: {{ .Values.config.snipeit.timezone | quote }}
             - name: APP_LOCALE
               value: {{ .Values.config.snipeit.locale | quote }}
+
           envFrom:
             - secretRef:
                 name: {{ include "snipeit.fullname" . }}
+            {{ if .Values.config.externalSecrets }}
+            - secretRef:
+                name: {{ .Values.config.externalSecrets }}
+            {{ end }}
+
           ports:
             - name: http
               containerPort: 80

--- a/snipeit/templates/external-manifests.yaml
+++ b/snipeit/templates/external-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/snipeit/templates/secret.yaml
+++ b/snipeit/templates/secret.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{ include "snipeit.labels" . | indent 4 | trim }}
 data:
+{{ if not .Values.config.externalSecrets }}
 {{- if .Values.mysql.enabled }}
   MYSQL_USER: {{ .Values.mysql.mysqlUser | b64enc }}
   MYSQL_DATABASE: {{ .Values.mysql.mysqlDatabase | b64enc }}
@@ -19,6 +20,7 @@ data:
   MYSQL_PORT_3306_TCP_ADDR: {{ .Values.config.mysql.externalDatabase.host | b64enc }}
   MYSQL_PORT_3306_TCP_PORT: {{ .Values.config.mysql.externalDatabase.port | quote | b64enc }}
   APP_KEY: {{ .Values.config.snipeit.key | b64enc }}
+{{- end }}
 {{- end }}
 {{ range $key, $value := .Values.config.snipeit.envConfig }}
   {{ $key }}: {{ $value | toString | b64enc }}

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -35,10 +35,19 @@ config:
     timezone: Europe/Berlin
     locale: en
     envConfig: {}
-
+  ## Name of the secret containing the database connection details
+  ## kubectl create secret generic my-db-secret \
+  ##   --from-literal=MYSQL_USER=<your_mysql_user> \
+  ##   --from-literal=MYSQL_DATABASE=<your_mysql_database> \
+  ##   --from-literal=MYSQL_PASSWORD=<your_mysql_password> \
+  ##   --from-literal=MYSQL_PORT_3306_TCP_ADDR=<your_mysql_host> \
+  ##   --from-literal=MYSQL_PORT_3306_TCP_PORT=<your_mysql_port> \
+  ##   --from-literal=APP_KEY=<your_app_key>
+ 
+  externalSecrets: ""
 mysql:
   ## Whether to deploy a mysql server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
-  enabled: true
+  enabled: false
   ## Create a database and a database user
   ##
   mysqlUser: snipeit
@@ -119,3 +128,5 @@ affinity: {}
 extraAnnotations: {}
   # Extra Annotations that will be added to the SnipeIT Pod(s)
   # app.kubernetes.io/instance: snipeit
+extraManifests: []
+


### PR DESCRIPTION
## Description:

This pull request enhances the Snipe-IT Helm chart by providing more flexibility and customization options for users. The updates allow users to utilize a manually created Kubernetes secret for managing database configuration and support the use of external manifests for additional resources or configurations.

### Benefits:

1. Manually created DB configuration secret:

   This update allows users to manage database secrets outside the Helm chart, which provides several benefits:
   a. Improved security: Users can manage sensitive database credentials with more control and restrict access to the secret.
   b. Reusability: If multiple instances of the Snipe-IT application are deployed in the same cluster, users can reuse the same secret without duplicating sensitive information in multiple secrets.
   c. Flexibility: Users can leverage existing secret management solutions to manage the database secrets and can update the secret without redeploying the Snipe-IT Helm release.

2. External manifests support:

   This enhancement allows users to include additional Kubernetes manifests for custom resources or other configurations, offering several advantages:
   a. Customization: Users can add custom resources or configurations, such as ConfigMaps, additional Secrets, or Ingress resources, without modifying the Snipe-IT Helm chart directly.
   b. Integration: Users can integrate Snipe-IT with other applications or services by deploying additional resources required for the integration, such as sidecar containers or custom network policies.
   c. Easier maintenance: As external manifests are decoupled from the core Helm chart, it becomes easier to maintain and upgrade the Snipe-IT Helm chart without losing custom configurations.

