### PR TITLE
Select PodDisruptionBudget API version based on k8s Version

### DIFF
--- a/cloudsql-proxy/Chart.yaml
+++ b/cloudsql-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cloudsql-proxy
-version: 2.0.2
+version: 2.0.3
 appVersion: "1.16"
 description: Google Cloud SQL Proxy
 keywords:

--- a/cloudsql-proxy/templates/poddisruptionbudget.yaml
+++ b/cloudsql-proxy/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if gt .Values.replicaCount 1.0 -}}
+{{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end -}}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "cloudsql-proxy.fullname" . }}


### PR DESCRIPTION
Similar change to https://github.com/t3n/helm-charts/pull/188 but for the Cloud SQL Proxy chart