### PR TITLE
Quote hostnames in Ingress

### DIFF
--- a/snipeit/templates/ingress.yaml
+++ b/snipeit/templates/ingress.yaml
@@ -32,14 +32,14 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}


### PR DESCRIPTION
Ingress hostnames can sometimes contain characters which require quoting in YAML such as wildcard hostnames.

This shows the required change in the snipe-it chart Ingress, but other charts in this repo are likely to benefit from a similar change. Posting this PR for discussion.