### PR TITLE
Snipe-IT: Add extraVolumeMounts and extraVolumes

### DIFF
--- a/snipeit/README.md
+++ b/snipeit/README.md
@@ -101,6 +101,8 @@ and their default values.
 | `tolerations`                        | Toleration labels for pod assignment                  | `[]`                           |
 | `affinity`                           | Affinity settings for pod assignment                  | `{}`                           |
 | `extraManifests`                     | Add additional manifests to deploy	                   | `[]`                           |
+| `extraVolumeMounts`                  | Additional volumeMounts to the container              | `[]`                           |
+| `extraVolume`                        | Additional volumes to the pod    	                   | `[]`                           |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```

--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -85,6 +85,9 @@ spec:
             - name: data
               mountPath: {{ .Values.persistence.sessions.mountPath }}
               subPath: {{ .Values.persistence.sessions.subPath }}
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12}}
+            {{- end }}
       volumes:
         - name: data
         {{- if .Values.persistence.enabled }}
@@ -92,6 +95,9 @@ spec:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "snipeit.fullname" . }}{{- end }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+          {{- toYaml .Values.extraVolumes | nindent 8}}
         {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -130,3 +130,16 @@ extraAnnotations: {}
   # app.kubernetes.io/instance: snipeit
 extraManifests: []
 
+extraVolumeMounts: []
+  # Additional volumeMounts to the container
+  # - name: secrets-store01-inline
+  #   mountPath: /mnt/secrets-store
+
+extraVolumes: []
+  # Additional volumes to the pod
+  # - csi:
+  #   driver: secrets-store.csi.k8s.io
+  #   readOnly: true
+  #   volumeAttributes:
+  #     secretProviderClass: "secret-csi-provider"
+  #  name : secrets-store01-inline


### PR DESCRIPTION
This pull request enhances the Snipe-IT Helm chart to allow the provisioning of additional volumes and mounts for the deployment.

One specific use case is the integration of the Secrets Store CSI Driver. Instead of storing MySQL credentials in the `values.yaml`, it's possible to securely store them in an external Secrets Manager. The secret will automatically sync when a pod requests the mount, thus the need to provide extra volumes and mounts to the deployment.