### PR TITLE
ability to turn off storage chown initcontainer 

### DIFF
--- a/snipeit/README.md
+++ b/snipeit/README.md
@@ -85,13 +85,14 @@ and their default values.
 | `mysql.persistence.accessMode`       | Access Mode of PV                                     | `ReadWriteOnce`                |
 | `mysql.persistence.size`             | Size of the PV                                        | `8Gi`                          |
 | `persistence.enabled`                | Whether or not Snipe-IT Data should be persisted      | `true`                         |
+| `persistence.initChownData`          | disable the chown init container-for aws efs csi      | `true`                         |
 | `persistence.annotations`            | Annotations for the PVC                               | `{}`                           |
 | `persistence.size`                   | Size of the persistent Snipe-IT Volume                | `2Gi`                          |
 | `replicaCount`                       | Number of Snipe-IT Pods to run                        | `1`                            |
 | `deploymentStrategy`                 | Deployment strategy	                                 | `{ "type": "RollingUpdate" }`  |
 | `revisionHistoryLimit`               | The number of old Replicas to keep to allow rollback. | `0`                            |
 | `service.type`                       | Type of service to create                             | `ClusterIP`                    |
-| `service.annotations`                 | Annotations of service to create                      | `{}`                           |
+| `service.annotations`                | Annotations of service to create                      | `{}`                           |
 | `service.clusterIP`                  | Internal cluster service IP                           | `nil`                          |
 | `service.loadBalancerIP`             | IP address to assign to load balancer (if supported)  | `nil`                          |
 | `service.loadBalancerSourceRanges`   | list of IP CIDRs allowed access to lb (if supported)  | `[]`                           |
@@ -129,6 +130,7 @@ container. A dynamically managed Persistent Volume Claim is used to keep the
 data across deployments, by default. This is known to work in GCE, AWS, and
 minikube.
 Alternatively, a previously configured Persistent Volume Claim can be used.
+when using AWS EFS CSI dynamic provisioning the created volume doesn't support chown command.
 
 
 #### Existing PersistentVolumeClaim

--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       {{- end }}
     {{- end }}
     spec:
+    {{ if .Values.persistence.initChownData }}
       initContainers:
         - name: config-data
           image: busybox
@@ -34,6 +35,7 @@ spec:
             - name: data
               mountPath: {{ .Values.persistence.sessions.mountPath }}
               subPath: {{ .Values.persistence.sessions.subPath }}
+    {{ end }}
       containers:
         - name: {{ include "snipeit.fullname" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -31,9 +31,10 @@ config:
     env: production
     debug: false
     url: http://example.local
+    ## the must start with the string "base64:......"
     key: ""
     timezone: Europe/Berlin
-    locale: en
+    locale: en-US
     envConfig: {}
   ## Name of the secret containing the database connection details
   ## kubectl create secret generic my-db-secret \
@@ -69,6 +70,9 @@ mysql:
 
 persistence:
   enabled: true
+  ## ability to disable the chown of the storage usefull with EKS EFS CSI dynamic provisioning 
+  ## EKS EFS CSI dynamic provisioning don't support chown command 
+  initChownData: true
   annotations: {}
   accessMode: ReadWriteOnce
   existingClaim: ""


### PR DESCRIPTION
This pull request includes updates to the `snipeit` Helm chart to support AWS EFS CSI dynamic provisioning and some minor configuration changes. The most important changes include adding an option to disable the `chown` command for AWS EFS CSI, updating locale settings, and providing additional documentation.

Support for AWS EFS CSI dynamic provisioning:

* [`snipeit/README.md`](diffhunk://#diff-f3a4081a000c920ec3335388282e96bec7210cf6407c9d56fddd607975f0e296R88): Added a note about AWS EFS CSI dynamic provisioning not supporting the `chown` command and introduced a new configuration option `persistence.initChownData`. [[1]](diffhunk://#diff-f3a4081a000c920ec3335388282e96bec7210cf6407c9d56fddd607975f0e296R88) [[2]](diffhunk://#diff-f3a4081a000c920ec3335388282e96bec7210cf6407c9d56fddd607975f0e296R133)
* [`snipeit/templates/deployment.yaml`](diffhunk://#diff-6dd979adbaa59a393f736bf63ebe663ad8b16b382d44f1de67de1acb10443e5dR29): Added conditional logic to include the `initContainers` section only if `persistence.initChownData` is enabled. [[1]](diffhunk://#diff-6dd979adbaa59a393f736bf63ebe663ad8b16b382d44f1de67de1acb10443e5dR29) [[2]](diffhunk://#diff-6dd979adbaa59a393f736bf63ebe663ad8b16b382d44f1de67de1acb10443e5dR38)
* [`snipeit/values.yaml`](diffhunk://#diff-20015325f4f8a2b6661f5ba4e854b5543eeafa43659408a26e8eee1c5cb79b9cR73-R75): Added `persistence.initChownData` configuration option to allow disabling the `chown` command for AWS EFS CSI dynamic provisioning.

Minor configuration changes:

* [`snipeit/values.yaml`](diffhunk://#diff-20015325f4f8a2b6661f5ba4e854b5543eeafa43659408a26e8eee1c5cb79b9cR34-R37): Updated the locale setting from `en` to `en-US` and added a note that the key must start with the string "base64:...".