### PR TITLE
fix SnipeIT uid being different in the newer releases (8.x)

### DIFF
--- a/snipeit/Chart.yaml
+++ b/snipeit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: snipeit
-version: 3.4.1
-appVersion: v6.0.14
+version: 3.4.2
+appVersion: v8.3.1
 description: A free open source IT asset/license management system
 keywords:
 - snipeit

--- a/snipeit/templates/deployment.yaml
+++ b/snipeit/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       initContainers:
         - name: config-data
           image: busybox
-          command: ["sh", "-c", "find {{ .Values.persistence.sessions.mountPath }} -not -user 1000 -exec chown 1000 {} \\+"]
+          command: ["sh", "-c", "find {{ .Values.persistence.sessions.mountPath }} -not -user {{ .Values.persistence.uid }} -exec chown {{ .Values.persistence.uid }}:{{ .Values.persistence.gid }} {} \\+"]
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.sessions.mountPath }}

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -88,6 +88,8 @@ persistence:
   sessions:
     mountPath: /var/www/html/storage/framework/sessions
     subPath: sessions
+  uid: 10000
+  gid: 50
 
 ingress:
   enabled: true


### PR DESCRIPTION
The UID is now configurable in the values, default is the ids used by snipeit in Version 8.x